### PR TITLE
feat: add a workflow to rotate a feedly token (take 2)

### DIFF
--- a/.github/workflows/rotate-token.yaml
+++ b/.github/workflows/rotate-token.yaml
@@ -54,8 +54,10 @@ jobs:
             const key = response.data.key;
             const key_id = response.data.key_id;
 
+            // Deal with base64 encoded token.json as a secret value
+            const value = btoa('${{steps.rotate.outputs.new_token_json}}');
+
             // Convert the message and key to Uint8Array's (Buffer implements that interface)
-            const value = '${{steps.rotate.outputs.new_token_json}}';
             const messageBytes = Buffer.from(value);
             const keyBytes = Buffer.from(key, 'base64');
 


### PR DESCRIPTION
# What

* add a workflow to rotate a feedly token (take 2)

# Why

* The token.json is expected to be base64 encoded.